### PR TITLE
Changed minimum accepted card limit to 0

### DIFF
--- a/trellowip.js
+++ b/trellowip.js
@@ -80,9 +80,9 @@ function List(el) {
             });
             
             if(cardCount >= cardLimit) {
-                if(cardCount == cardLimit) { 
+                if(cardCount == cardLimit && cardLimit != 0) { 
                     $list.addClass('at-limit');
-                } else {
+                } else if (cardCount > cardLimit) {
                     $list.addClass('over-limit');
                 }
             }


### PR DESCRIPTION
**User scenario:** We have a card lane named "Blocked" which should not have any card ideally. This change is to cater that need.  
For a lane with card limit of 0, 'at-limit' class should not be attached to it.
