### PR TITLE
Add Firefox support (by add few lines in manifest)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,16 @@
 {
     "manifest_version": 2,
-    "content_scripts": [ 
+    "applications": {
+      "gecko": {
+        "id": "trellowip@bobchao.net"
+      }
+    },
+    "content_scripts": [
         {
             "matches": [ "https://trello.com/*" ],
             "css": [ "trellowip.css" ],
             "js": [ "jquery-1.7.1.min.js", "trellowip.js" ]
-        } 
+        }
     ],
     "description": "Adds work-in-progress limits to Trello lists supporting a Kanban workflow.",
     "icons": {
@@ -14,4 +19,3 @@
     "name": "Kanban WIP for Trello",
     "version": "0.3.3"
 }
-


### PR DESCRIPTION
Since Firefox Nightly is already support all the feature needed for this extension, I'll suggest that we add a few line in the manifest file to gain an experimental Firefox support. I have already tried the modified code with my computer and it works well (Firefox Nightly 46).

![wpng](https://cloud.githubusercontent.com/assets/168931/12082279/2a8bdf32-b2cb-11e5-8336-c0c98709546f.png)

For more information on porting Chrome extension to Firefox: https://hacks.mozilla.org/2015/10/porting-chrome-extensions-to-firefox-with-webextensions/  (For content_script based extensions, it's a piece of cake.)

In Q2 this year we will be able to submit this extension to the official Firefox Add-ons site: https://bugzilla.mozilla.org/show_bug.cgi?id=1210037 
